### PR TITLE
Make sure sockets and device connections are cleaned up

### DIFF
--- a/src/rmp.py
+++ b/src/rmp.py
@@ -38,10 +38,13 @@ class rmpNetwork():
         self.psn = 0
         self.reliable = 0
 
+    def __del__(self):
+        socket_closer("class rmpNetwork __del__", self.sock)
+
     def CloseNetwork(self):
         """!@brief Close previously opened socket.
         """
-        self.sock.close()
+        socket_closer("class rmpNetwork CloseNetwork", self.sock)
         return
 
     def recvfrom_to(self, buff):
@@ -278,7 +281,7 @@ class rmpNetwork():
 
     def socket_flush(self):
         print("Flushing UCP socket...")
-        self.sock.close()
+        socket_closer("class rmpNetwork socket_flush", self.sock)
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # Internet # UDP
 

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -10,7 +10,7 @@ import struct
 import contextlib
 
 from .transport import Transport
-from .utils import create_meta_dictionary, get_hostname, get_kwarg
+from .utils import create_meta_dictionary, get_hostname, get_kwarg, socket_closer
 
 LOGGER = logging.getLogger(__name__)
 
@@ -190,6 +190,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
                 result_queue.put('Could not send file to upload port({}): {}'.format(
                                  port, e))
             finally:
+                socket_closer("sendfile to {}:{}".format(targethost, port), upload_socket)
                 self.logger.info('%s: upload thread complete at %.3f' %
                                 (targethost, time.time()))
 

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -116,6 +116,16 @@ class KatcpTransport(Transport, katcp.CallbackClient):
         self.connect()
         self.logger.info('%s: port(%s) created and connected.' % (self.host, port))
 
+    def __del__(self):
+        """
+        When the KatcpTransport object is reclaimed, make sure to
+        disconnect from the device server.
+        """
+        try:
+            self.disconnect()
+        except:
+            pass
+
     @staticmethod
     def test_host_type(host_ip, timeout=5):
         """

--- a/src/transport_skarab.py
+++ b/src/transport_skarab.py
@@ -14,7 +14,7 @@ from . import skarab_definitions as sd
 from . import skarab_fileops as skfops
 from .transport import Transport
 from .network import IpAddress
-
+from .utils import socket_closer
 
 __author__ = 'tyronevb'
 __date__ = 'April 2016'
@@ -183,6 +183,9 @@ class SkarabTransport(Transport):
         # self.gbes.append(FortyGbe(self, 0))
         # # self.gbes.append(FortyGbe(self, 0, 0x54000 - 0x4000))
 
+    def __del__(self):
+        socket_closer("class SkarabTransport __del__", self._skarab_control_sock)
+
     @staticmethod
     def test_host_type(host_ip):
         """
@@ -197,6 +200,7 @@ class SkarabTransport(Transport):
             request_payload = request_object.create_payload(0xffff)
             sctrl_sock.sendto(request_payload, skarab_eth_ctrl_port)
             data_ready = select.select([sctrl_sock], [], [], 1)
+	    socket_closer("class SkarabTransport test_host_type", sctrl_sock)
             if len(data_ready[0]) > 0:
                 # self.logger.debug('%s seems to be a SKARAB' % host_ip)
                 return True

--- a/src/transport_skarab.py
+++ b/src/transport_skarab.py
@@ -200,7 +200,7 @@ class SkarabTransport(Transport):
             request_payload = request_object.create_payload(0xffff)
             sctrl_sock.sendto(request_payload, skarab_eth_ctrl_port)
             data_ready = select.select([sctrl_sock], [], [], 1)
-	    socket_closer("class SkarabTransport test_host_type", sctrl_sock)
+            socket_closer("class SkarabTransport test_host_type", sctrl_sock)
             if len(data_ready[0]) > 0:
                 # self.logger.debug('%s seems to be a SKARAB' % host_ip)
                 return True

--- a/src/transport_tapcp.py
+++ b/src/transport_tapcp.py
@@ -100,6 +100,12 @@ class TapcpTransport(Transport):
         self.server_timeout = 0.1 # Microblaze timeout period. So that if a command fails we can wait for the microblaze to terminate the connection before retrying
         self.retries = kwargs.get('retries', 8) # These are retries of a complete transaction (each of which has it's ofw TFTP retries).
 
+    __del__(self):
+        try:
+            self.t.context.end()
+        except:
+            pass
+    
     @staticmethod
     def test_host_type(host_ip):
         """
@@ -138,8 +144,16 @@ class TapcpTransport(Transport):
             buf = BytesIO()
             board.download('%s.%x.%x' % ('sys_clkcounter', 0, 1),
                            buf, timeout=3)
+            try:
+                board.context.end()
+            except:
+                pass
             return True
         except Exception:
+            try:
+                board.context.end()
+            except:
+                pass
             return False
 
     def listdev(self):
@@ -414,10 +428,18 @@ class TapcpTransport(Transport):
             try:
                 buf = BytesIO()
                 self.t.download('%s.%x.%x' % (device_name, offset//4, size//4), buf, timeout=self.timeout)
+                try:
+                    self.t.context.end()
+                except:
+                    pass
                 return buf.getvalue()
             except TFTPY.TftpShared.TftpFileNotFoundError:
                 self.logger.error('Device {0} not found'.format(device_name))
                 # If the file's not there, don't bother retrying
+                try:
+                    self.t.context.end()
+                except:
+                    pass
                 break
             except:
                 # if we fail to get a response after a bunch of packet re-sends, wait for the
@@ -432,6 +454,10 @@ class TapcpTransport(Transport):
         try:
             buf = BytesIO()
             self.t.download('%s.%x.%x' % (device_name, offset//4, size//4), buf, timeout=self.timeout)
+            try:
+                self.t.context.end()
+            except:
+                pass
             return buf.getvalue()
         except:
             try:
@@ -456,6 +482,10 @@ class TapcpTransport(Transport):
             try:
                 buf = BytesIO(data)
                 self.t.upload('%s.%x.0' % (device_name, offset//4), buf, timeout=self.timeout)
+                try:
+                    self.t.context.end()
+                except:
+                    pass
                 return
             except:
                 # if we fail to get a response after a bunch of packet re-sends, wait for the
@@ -470,6 +500,10 @@ class TapcpTransport(Transport):
         try:
             buf = BytesIO(data)
             self.t.upload('%s.%x.0' % (device_name, offset//4), buf, timeout=self.timeout)
+            try:
+                self.t.context.end()
+            except:
+                pass
         except:
             try:
                 self.t.context.end()

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@ import queue
 import time
 import logging
 import sys
+import socket
 
 LOGGER = logging.getLogger(__name__)
 
@@ -585,5 +586,27 @@ def deprogram_hosts(host_list):
     if len(already_deprogrammed) != 0:
         print('%s: already deprogrammed.' % already_deprogrammed)
     threaded_fpga_function(fpgas, 10, 'disconnect')
+
+def socket_closer(arg_caller, arg_socket):
+    """
+    Ref: https://docs.python.org/3/library/socket.html
+    See warnings about close() and notes on shutdown().
+
+    Shutdown and close the specified socket.
+    Ignore all exceptions.
+
+    :param arg_caller: Identity and/or context of caller.
+    :param arg_socket: socket to be shutdown & closed.
+    :return: nothing
+    """
+    LOGGER.debug("socket_closer: called from {}".format(arg_caller))
+    try:
+        arg_socket.shutdown(socket.SHUT_RDWR)
+    except:
+        pass
+    try:
+        arg_socket.close()
+    except:
+        pass
 
 # end


### PR DESCRIPTION
```/src/rmp.py```:
    ```__del__``` - Added to make sure that the self.sock is shutdown & closed.
                           when the rmpNetwork object is reclaimed.
    ```CloseNetwork``` - The self.sock socket was being closed but not immediately shutdown.
    ```socket_flush``` - The self.sock socket was being closed but not immediately shutdown.

```./src/transport_katcp.py```:
   ```__del__``` - When the KatcpTransport object is reclaimed, make sure to
                           disconnect from the device server.
    ```sendfile``` - The upload_socket was not being shutdown nor closed. Lack of close() may not be an issue in Python 3 context manager on Linux/Unix.  Elsewhere?

```./src/transport_skarab.py```:
    ```__del__``` - Add to make sure that the self._skarab_control_sock is shutdown & closed
                           when the SkarabTransport object is being reclaimed.
   ```test_host_type``` - The sctrl_sock socket was not being shutdown nor closed.  Lack of close() may not be an issue in Python 3 context manager on Linux/Unix.  Elsewhere?

```./src/utils.py```:
   ```socket_closer``` - new centralized function to shutdown and close sockets.