### PR TITLE
Fixes to setup.py, debug/test_rapid_katcp.py, and src/transport_katcp.py

### DIFF
--- a/debug/test_rapid_katcp.py
+++ b/debug/test_rapid_katcp.py
@@ -48,12 +48,12 @@ def init_snaps(arg_counter, arg_snap_list):
         asnaps.append(snap_instance)
     return asnaps
 
-def main():
+def main(nloops=NLOOPS):
 	counter = 0
 	if SIMULATION:
 	    f = []
 	print("main: Begin loops, initial count of open FDs:", count_ofds())
-	while counter < NLOOPS:
+	while counter < nloops:
 	    snaps = init_snaps(counter, SNAP_NAMES)
 	    print("main: count of open FDs after init_snaps:", count_ofds())
 	    disconnect_snaps(counter, SNAP_NAMES, snaps)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
         'tftpy==0.8.0',
     ],
     packages=['casperfpga', 'casperfpga.progska'],
-    package_dir={'casperfpga': 'src', 'casperfpga': 'debug', 'casperfpga.progska': 'progska'},
+    package_dir={'casperfpga': 'src', 'casperfpga.debug': 'debug', 'casperfpga.progska': 'progska'},
     package_data={'casperfpga': data_files},
     scripts=glob.glob('scripts/*'),
     setup_requires=['katversion'],

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
         'redis',
         'tftpy==0.8.0',
     ],
-    packages=['casperfpga', 'casperfpga.progska'],
+    packages=['casperfpga', 'casperfpga.debug', 'casperfpga.progska'],
     package_dir={'casperfpga': 'src', 'casperfpga.debug': 'debug', 'casperfpga.progska': 'progska'},
     package_data={'casperfpga': data_files},
     scripts=glob.glob('scripts/*'),

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -251,6 +251,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
         Disconnect from the device server.
         :return:
         """
+        katcp.CallbackClient.stop(self)
         if self.is_connected():
             katcp.CallbackClient.disconnect(self)
         self.join(timeout=self._timeout)


### PR DESCRIPTION
setup.py - dictionary clash.

debug/test_rapid_katcp.py - added a loop count parameter.

src/transport_katcp.py - added a katcp.CallbackClient.stop(self) in disconnect() which appears to have stopped the runaway open file descriptor anomaly.