### PR TITLE
katcprequest retry loop (untested initial draft)

### DIFF
--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -234,7 +234,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
         self.logger.info('%s: disconnected' % self.host)
 
     def katcprequest(self, name, request_timeout=-1.0, require_ok=True,
-                     request_args=()):
+                     request_args=(), max_retries=3, retry_delay_s=0.5):
         """
         Make a blocking request to the KATCP server and check the result.
         Raise an error if the reply indicates a request failure.
@@ -244,13 +244,23 @@ class KatcpTransport(Transport, katcp.CallbackClient):
             must time out
         :param require_ok: will we raise an exception on a response != ok
         :param request_args: request arguments.
+        :param max_retries: maximum number of retries in the case of errors (3).
+        :param retry_delay_s: the delay between retries in the case of errors (0.5 seconds).
         :return: tuple of reply and informs
         """
         # TODO raise sensible errors
         if request_timeout == -1:
             request_timeout = self._timeout
         request = katcp.Message.request(name, *request_args)
-        reply, informs = self.blocking_request(request, timeout=request_timeout)
+        reply = None
+        retries = 0
+
+        while retries == 0 or (require_ok and retries < max_retries and (reply.arguments[0] != katcp.Message.OK)):
+            if retries > 0:
+                time.delay(retry_delay_s)
+            reply, informs = self.blocking_request(request, timeout=request_timeout)
+            retries += 1
+        
         if (reply.arguments[0] != katcp.Message.OK) and require_ok:
             if reply.arguments[0] == katcp.Message.FAIL:
                 raise KatcpRequestFail(

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -257,7 +257,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
 
         while retries == 0 or (require_ok and retries < max_retries and (reply.arguments[0] != katcp.Message.OK)):
             if retries > 0:
-                time.delay(retry_delay_s)
+                time.sleep(retry_delay_s)
             reply, informs = self.blocking_request(request, timeout=request_timeout)
             retries += 1
         


### PR DESCRIPTION
Instead of wrapping upstream functions in try...except blocks to handle sporadic transport failures, it would be nice to have the request retry a few times instead.

I'm requested the PR into this repo as it is linked to [realtimeradio/ata_snap](https://github.com/realtimeradio/ata_snap/tree/main/sw), which is currently the upstream package where I am experiencing sporadic transport failures being raised.