### PR TITLE
Fix snapadc stuff

### DIFF
--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -404,7 +404,7 @@ class SnapAdc(object):
 
     # A lane in this method actually corresponds to a "branch" in HMCAD1511 datasheet.
     # But I have to follow the naming convention of signals in casper repo.
-    def bitslip(self, chipSel=None, laneSel=None):
+    def bitslip(self, chipSel=None, laneSel=None, verify=False):
         """ Reorder the parallelize data for word-alignment purpose
         
         Reorder the parallelized data by asserting a itslip command to the bitslip 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -398,6 +398,7 @@ class SnapAdc(object):
                 length = 1024
             vals = self.ram[ram]._read(addr=0, size=length)
             vals = np.array(struct.unpack(fmt,vals)).reshape(-1,8)
+            return vals
         else:
             raise ValueError
 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -506,10 +506,7 @@ class SnapAdc(object):
         elif laneSel not in self.laneList:
             raise ValueError("Invalid parameter")
 
-        if not isinstance(tap, (int, np.int64)):
-            raise ValueError("Invalid parameter")
-            if isinstance(tap, np.int64):
-                tap = int(tap)   # Fix for Py3
+        tap = int(tap) # Fix for Py3
  
         strl = ','.join([str(c) for c in laneSel])
         strc = ','.join([str(c) for c in chipSel])


### PR DESCRIPTION
There were a fair bit of howler-type mistakes in the casperfpga.snapadc module. I think we got them ironed out here, but the py38 version of casperfpga is unusable for SNAP work without these changes, so I recommend merging this into both py38 and py38-dev.

Thanks!
@AaronParsons  