### PR TITLE
Fix `str` / `bytes` mixup in `_read_design_info_from_host`

### DIFF
--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -825,8 +825,11 @@ class KatcpTransport(Transport, katcp.CallbackClient):
                     self.logger.error('FEWER than THREE meta inform '
                                  'arguments: %s' % str(inform.arguments))
                     continue
-            for arg in inform.arguments:
-                arg = arg.replace('\\_', ' ')
+            # Mysteriously, the inform arguments are sometimes strings??
+            # "Don't blame me, blame katcp"
+            for i, arg in enumerate(inform.arguments):
+                if isinstance(arg, str):
+                    inform.arguments[i] = str.encode(arg)
             name = inform.arguments[0].decode()
             tag = inform.arguments[1].decode()
             param = inform.arguments[2].decode()

--- a/src/transport_katcp.py
+++ b/src/transport_katcp.py
@@ -826,7 +826,7 @@ class KatcpTransport(Transport, katcp.CallbackClient):
                                  'arguments: %s' % str(inform.arguments))
                     continue
             for arg in inform.arguments:
-                arg = arg.replace(b'\_', b' ')
+                arg = arg.replace('\\_', ' ')
             name = inform.arguments[0].decode()
             tag = inform.arguments[1].decode()
             param = inform.arguments[2].decode()


### PR DESCRIPTION
The bit that did 
```python
 for arg in inform.arguments:
    arg = arg.replace(b'\_', b' ')
```
never did anything because `.replace` doesn't mutate and arg is a copy, not a reference.

Additionally, it seems that katcp-python is filling `inform.arguments` with `bytes` and `str`, for some reason. This is a quick fix to make sure they are all bytes - which fixes programming an fpg file (something that I guess was broken?).

But really this needs to be fixed upstream in katcp, showcasing more of the problems with conflating bytes and strings (as per my mailing list conversation about this).
