### PR TITLE
Fix references to deprecated collections classes

### DIFF
--- a/src/casperfpga.py
+++ b/src/casperfpga.py
@@ -4,7 +4,7 @@ import time
 import socket
 from time import strptime
 import string
-import collections
+from collections.abc import Callable
 
 from . import register
 from . import sbram
@@ -625,7 +625,7 @@ class CasperFpga(object):
             except KeyError:
                 pass
             else:
-                if not isinstance(known_device_class, collections.Callable):
+                if not isinstance(known_device_class, Callable):
                     raise TypeError('%s is not a callable Memory class - '
                                     'that\'s a problem.' % known_device_class)
 
@@ -692,7 +692,7 @@ class CasperFpga(object):
             except KeyError:
                 pass
             else:
-                if not isinstance(known_device_class, collections.Callable):
+                if not isinstance(known_device_class, Callable):
                     errmsg = '{} is not a callable ADC Class'.format(known_device_class)
                     raise TypeError(errmsg)
 

--- a/src/i2c/i2c_sn.py
+++ b/src/i2c/i2c_sn.py
@@ -1,5 +1,6 @@
 import numpy as np, logging, time, struct
-import collections,crcmod
+import crcmod
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class DS28CM00:
     def crc8(self,data,poly=0x131,initVal=0):
 
         crc = initVal
-        if isinstance(data,collections.Iterable):
+        if isinstance(data, Iterable):
             for d in data:
                 crc = self.crc8(d,poly,crc)
             return crc

--- a/src/i2c_sn.py
+++ b/src/i2c_sn.py
@@ -1,5 +1,6 @@
 import numpy as np, logging, time, struct
-import collections,crcmod
+import crcmod
+from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ class DS28CM00:
     def crc8(self,data,poly=0x131,initVal=0):
 
         crc = initVal
-        if isinstance(data,collections.Iterable):
+        if isinstance(data, Iterable):
             for d in data:
                 crc = self.crc8(d,poly,crc)
             return crc


### PR DESCRIPTION
`collections.<Callable/Iterable>` were deprecated in Python 3.3 and have been removed in 3.10