### PR TITLE
Bump katcp version for python 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         'IPython',
         'future',
         'numpy',
-        'katcp==0.9.1',
+        'katcp==0.9.3',
         'katversion',
         'odict',
         'setuptools',


### PR DESCRIPTION
We fixed deprecations for py3.9 on our end, but we need to bump the katcp version to use their fixes of the same problems.