### PR TITLE
Py311

### DIFF
--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy: 
             matrix:
-                python-version: ["3.8.3"]
+                python-version: [3.8, 3.11]
 
         steps:
             - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setuptools.setup(
         'IPython',
         'future',
         'numpy',
-        'katcp==0.9.1',
+        'katcp>=0.9.3',
         'katversion',
         'odict',
         'setuptools',

--- a/src/casperfpga.py
+++ b/src/casperfpga.py
@@ -4,7 +4,12 @@ import time
 import socket
 from time import strptime
 import string
-import collections
+try:
+    from collections import Callable
+except(ImportError):
+    # starting in Python 3.10, Callable is in abc
+    from collections.abc import Callable
+
 
 from . import register
 from . import sbram
@@ -625,7 +630,7 @@ class CasperFpga(object):
             except KeyError:
                 pass
             else:
-                if not isinstance(known_device_class, collections.Callable):
+                if not isinstance(known_device_class, Callable):
                     raise TypeError('%s is not a callable Memory class - '
                                     'that\'s a problem.' % known_device_class)
 
@@ -692,7 +697,7 @@ class CasperFpga(object):
             except KeyError:
                 pass
             else:
-                if not isinstance(known_device_class, collections.Callable):
+                if not isinstance(known_device_class, Callable):
                     errmsg = '{} is not a callable ADC Class'.format(known_device_class)
                     raise TypeError(errmsg)
 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -1020,7 +1020,7 @@ class SnapAdc(object):
     def from_device_info(cls, parent, device_name, device_info, initialize=False, **kwargs):
         """
         Process device info and the memory map to get all the necessary info
-        and return a SKARAB ADC instance.
+        and return a ADC instance.
         :param parent: The parent device, normally a casperfpga instance
         :param device_name:
         :param device_info:
@@ -1029,4 +1029,8 @@ class SnapAdc(object):
         :param kwargs:
         :return:
         """
-        return cls(parent, device_name, device_info, initialize, **kwargs)
+        host = parent
+        #return cls(parent, device_name, device_info, initialize, **kwargs)
+        # XXX should device_info be passed as kwargs to cls? Would require renaming
+        # some parameters, so am not for now.
+        return cls(host)

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -962,8 +962,9 @@ class SnapAdc(object):
             logger.error('Frame clock NOT aligned.\n{0}'.format(str(errs)))
             return False
 
-    def rampTest(self, nchecks=300, retry=False):
-        chips = self.adcList
+    def rampTest(self, chips=None, nchecks=300, retry=False):
+        if chips is None:
+            chips = self.adcList
         self.logger.debug('Ramp test on ADCs: %s' % str(chips))
         failed_chips = {}
         self.setDemux(numChannel=1)
@@ -972,7 +973,7 @@ class SnapAdc(object):
         self.adc.test("en_ramp")
         for cnt in range(nchecks):
             self.snapshot()
-            for chip,d in self.readRAM(signed=False).items():
+            for chip,d in self.readRAM(chips, signed=False).items():
                 ans = (predicted + d[0,0]) % 256
                 failed_lanes = np.sum(d != ans, axis=0)
                 if np.any(failed_lanes) > 0:


### PR DESCRIPTION
These are just minor changes to make casperfpga Python 3.11 compliant (notably, Collections moved), to restore chip select capability in SnapAdc testing/initialization, and to make SnapAdc.from_device_info work at a basic level.  Also, setup.py pinned the version of katcp at 0.9.1, but that version is not Python 3.11 compliant, so switched the req to >0.9.3